### PR TITLE
ensure zeromq is enabled in bitcoind

### DIFF
--- a/config.env
+++ b/config.env
@@ -6,8 +6,8 @@ export BITCOIND_TYPE=$(yq e '.bitcoin-node.type' /root/start9/config.yaml)
 export BITCOIND_IP="${BITCOIND_TYPE}.embassy"
 export BITCOIND_RPC_USER=$(yq e '.bitcoin-node.username' /root/start9/config.yaml)
 export BITCOIND_RPC_PASSWORD=$(yq e '.bitcoin-node.password' /root/start9/config.yaml)
-export BITCOIND_ZMQ_BLK_HASH=9502
-export BITCOIND_ZMQ_RAWTXS=9501
+export BITCOIND_ZMQ_BLK_HASH=28332
+export BITCOIND_ZMQ_RAWTXS=28333
 
 if [ "$BITCOIND_TYPE" = "bitcoind-testnet" ]; then
 	export COMMON_BTC_NETWORK=testnet

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -71,12 +71,24 @@ dependencies:
       type: "opt-out"
       how: Use the Bitcoin Core (default)
     description: Used to subscribe to new block events from a full archival node
+    config:
+      check:
+        type: script
+      auto-configure:
+        type: script
+    requires-runtime-config: true
   bitcoind-testnet:
     version: ">=0.21.1.2 <29.0.0"
     requirement:
       type: "opt-in"
       how: Use the Bitcoin Core Testnet4
     description: Used to subscribe to new block events from a full archival node (testnet)
+    config:
+      check:
+        type: script
+      auto-configure:
+        type: script
+    requires-runtime-config: true
   fulcrum:
     version: ">=1.11.0"
     requirement:

--- a/scripts/procedures/dependencies.ts
+++ b/scripts/procedures/dependencies.ts
@@ -17,6 +17,7 @@ const matchBitcoindConfig = shape({
       mode: string
     })
   }),
+  'zmq-enabled': boolean
 });
 
 const matchIndexerConfig = shape({
@@ -39,6 +40,10 @@ export const dependencies: T.ExpectedExports.dependencies = {
 
       if (!config.rpc.enable) {
         return { error: "Must have RPC enabled" };
+      }
+
+      if (!config['zmq-enabled']) {
+	return { error: "Must have ZeroMQ enabled" };
       }
 
       if (config.advanced.pruning.mode !== "disabled") {
@@ -66,6 +71,8 @@ export const dependencies: T.ExpectedExports.dependencies = {
 
       config.rpc.enable = true;
 
+      config['zmq-enabled'] = true;
+
       if (config.advanced.pruning.mode !== "disabled") {
         config.advanced.pruning.mode = "disabled";
       }
@@ -92,6 +99,10 @@ export const dependencies: T.ExpectedExports.dependencies = {
         return { error: "Must have RPC enabled" };
       }
 
+      if (!config['zmq-enabled']) {
+	return { error: "Must have ZeroMQ enabled" };
+      }
+
       if (config.advanced.pruning.mode !== "disabled") {
         return { error: "Pruning must be disabled (must be an archival node)" };
       }
@@ -116,6 +127,8 @@ export const dependencies: T.ExpectedExports.dependencies = {
       const config = matchBitcoindConfig.unsafeCast(configInput);
 
       config.rpc.enable = true;
+
+      config['zmq-enabled'] = true;
 
       if (config.advanced.pruning.mode !== "disabled") {
         config.advanced.pruning.mode = "disabled";


### PR DESCRIPTION
the Dojo tracker relies on a zeromq subscription to pick up on new events like blocks and transactions on the network. This PR correctly sets the zeromq ports and ensures that zeromq is enabled in bitcoind.