### PR TITLE
Remove unnecessary case statement

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -79,7 +79,6 @@ EOF
 	for f in /docker-entrypoint-initdb.d/*; do
 		case "$f" in
 			*.sql)    echo "$0: running $f"; sed "1iUSE \`$MYSQL_DATABASE\`;" "$f" | /usr/bin/mysqld --user=mysql --bootstrap --verbose=0 --skip-name-resolve --skip-networking=0; echo ;;
-			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | sed "1iUSE \`$MYSQL_DATABASE\`;" | /usr/bin/mysqld --user=mysql --bootstrap --verbose=0 --skip-name-resolve --skip-networking=0 < "$f"; echo ;;
 			*)        echo "$0: ignoring or entrypoint initdb empty $f" ;;
 		esac
 		echo


### PR DESCRIPTION
We don't have any .sql.gz, plus this line was incorrect per shellcheck:
- Make sure not to read and write the same file in the same pipeline [SC2094](https://www.shellcheck.net/wiki/SC2094)
- This redirection overrides piped input. To use both, merge or pass [SC2259](https://www.shellcheck.net/wiki/SC2259)